### PR TITLE
Add handling of `FileNotFoundError` when `xprintidle` is not installed

### DIFF
--- a/pitopd/idle_monitor.py
+++ b/pitopd/idle_monitor.py
@@ -73,6 +73,10 @@ class IdleMonitor:
 
             try:
                 xprintidle_resp = check_output(["xprintidle"], stderr=FNULL)
+            except FileNotFoundError:
+                logger.warning("xprintidle not found")
+                break
+
             except CalledProcessError:
                 logger.warning(
                     "Unable to call xprintidle - have non-network local"


### PR DESCRIPTION
When installing `pi-topd` on top of Raspberry Pi OS Lite, this is required in order for the service not to fail.