### PR TITLE
Fix pybuild packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,10 +20,7 @@ Depends:
 # Hardware interface management for devices and peripherals
  raspi-config,
 Suggests:
-# Low battery warnings
- notify-send-ng,
-# User idle time
- xprintidle,
+ pi-topd-extra,
 Description: pi-top System Daemon
  Core pi-top service for interfacing with pi-top hardware.
  Provides support for management of all pi-top units.
@@ -33,3 +30,30 @@ Description: pi-top System Daemon
  .
  Additional functionality is provided to communicate with the system,
  such as automatically blanking the display after a timeout.
+
+Package: pi-topd-extra
+Architecture: all
+Depends:
+ ${misc:Depends},
+ pi-topd-notify,
+ pi-topd-screen-blank,
+Description: Additional pi-topd Support (e.g. Desktop Components) dummy package
+ Provides additional functionality to pi-topd, primarily for displays.
+
+Package: pi-topd-notify
+Architecture: all
+Depends:
+ ${misc:Depends},
+# Low battery warnings
+ notify-send-ng,
+Description: pi-topd Notification Support dummy package
+ Provides notification support for pi-topd.
+
+Package: pi-topd-screen-blank
+Architecture: all
+Depends:
+ ${misc:Depends},
+# User idle time
+ xprintidle,
+Description: pi-topd Display Blanking Support dummy package
+ Provides display blanking support for pi-topd.

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,7 @@
 #!/usr/bin/make -f
 
 export PYBUILD_NAME=pitopd
+export PYBUILD_DESTDIR_python3=debian/pi-topd/
 
 %:
 	dh $@ --buildsystem=pybuild


### PR DESCRIPTION
This should fix packaging issues that were worked around in v5.1.0-4.
Source: https://wiki.debian.org/Python/Pybuild

The reason that this is needed is that, without a `*.install` file and multiple packages defined, the default behaviour is `python3-{pybuild name}`. This is the name of the folder that files are packaged into - and needs to be forced to match our main package.