### PR TITLE
Take control of miniscreen on initialization

### DIFF
--- a/pitopd/app.py
+++ b/pitopd/app.py
@@ -103,6 +103,9 @@ class App:
                 self._interface_manager.spi0 = spi_bus_to_use == 0
                 self._interface_manager.spi1 = spi_bus_to_use == 1
 
+            logger.info("Taking control of miniscreen")
+            self.on_request_set_oled_pi_control(True)
+
         # Check if any peripherals need to be set up
         self._peripheral_manager.auto_initialise_peripherals()
 


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/OS-1238) |


#### Main changes

On initialization, `pi-topd` will tell the hub to give control of the miniscreen to the device.

Before this was done by `pt-miniscreen` but since it starts later in the boot process, users would see a 'no SD card animation'. Since `pi-topd` starts before, we gain a few seconds.


#### Screenshots (feature, test output, profiling, dev tools etc)

N/A

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
