### PR TITLE
Handle unexpected changes to SPI bus

### DIFF
--- a/pitopd/app.py
+++ b/pitopd/app.py
@@ -97,9 +97,7 @@ class App:
         if self.device_id == DeviceID.pi_top_4:
             logger.info("Running on a pi-top [4]. Configuring SPI bus for OLED...")
 
-            spi_bus_to_use = state.get(
-                "oled", "spi_bus", fallback=self._hub_manager.get_oled_spi_bus()
-            )
+            spi_bus_to_use = self._hub_manager.get_oled_spi_bus()  # from state
             logger.info(f"Hub says to use SPI bus {spi_bus_to_use}")
 
             if spi_bus_to_use is not None:

--- a/pitopd/app.py
+++ b/pitopd/app.py
@@ -101,8 +101,7 @@ class App:
             logger.info(f"Hub says to use SPI bus {spi_bus_to_use}")
 
             if spi_bus_to_use is not None:
-                # TODO: don't display notification
-                self.on_request_set_oled_spi_bus(spi_bus_to_use)
+                self.on_request_set_oled_spi_bus(spi_bus_to_use, notify=False)
 
             logger.info("Taking control of miniscreen")
             self.on_request_set_oled_pi_control(True)
@@ -219,13 +218,13 @@ class App:
     def on_request_get_oled_spi_bus(self):
         return self._hub_manager.get_oled_spi_bus()
 
-    def on_request_set_oled_spi_bus(self, spi_bus):
+    def on_request_set_oled_spi_bus(self, spi_bus, notify=True):
         logger.info(f"OLED SPI bus requested to be changed to use {spi_bus}")
 
         # Configure Raspberry Pi with correct bus
         self._interface_manager.spi0 = spi_bus == 0
         self._interface_manager.spi1 = spi_bus == 1
-        if spi_bus == 0:
+        if spi_bus == 0 and notify:
             self._notification_manager.display_old_spi_bus_still_active_message()
 
         # Update state and write to hub

--- a/pitopd/app.py
+++ b/pitopd/app.py
@@ -97,10 +97,11 @@ class App:
         if self.device_id == DeviceID.pi_top_4:
             logger.info("Running on a pi-top [4]. Configuring SPI bus for OLED...")
 
-            spi_bus_to_use = self._hub_manager.get_oled_spi_bus()  # from state
+            spi_bus_to_use = self._hub_manager.get_oled_spi_bus()
             logger.info(f"Hub says to use SPI bus {spi_bus_to_use}")
 
             if spi_bus_to_use is not None:
+                # TODO: don't display notification
                 self.on_request_set_oled_spi_bus(spi_bus_to_use)
 
             logger.info("Taking control of miniscreen")
@@ -227,7 +228,7 @@ class App:
         if spi_bus == 0:
             self._notification_manager.display_old_spi_bus_still_active_message()
 
-        # Write to hub
+        # Update state and write to hub
         self._hub_manager.set_oled_use_spi0(spi_bus == 0)
 
     ###########################################

--- a/pitopd/app.py
+++ b/pitopd/app.py
@@ -5,7 +5,6 @@ from pitop.common.common_ids import DeviceID
 from systemd.daemon import notify
 
 from . import state
-from .event import AppEvents, event_emitter
 from .hub_manager import HubManager
 from .idle_monitor import IdleMonitor
 from .interface_manager import InterfaceManager
@@ -105,9 +104,6 @@ class App:
 
             logger.info("Taking control of miniscreen")
             self.on_request_set_oled_pi_control(True)
-            event_emitter.on(
-                AppEvents.SPI_BUS_CHANGED, self.on_request_set_oled_spi_bus
-            )
 
         # Check if any peripherals need to be set up
         self._peripheral_manager.auto_initialise_peripherals()

--- a/pitopd/event.py
+++ b/pitopd/event.py
@@ -1,9 +1,0 @@
-from enum import Enum, auto
-
-from pyee import EventEmitter
-
-event_emitter = EventEmitter()
-
-
-class AppEvents(Enum):
-    SPI_BUS_CHANGED = auto()  # 0, 1: SPI bus in use

--- a/pitopd/pthub3/pthub3.py
+++ b/pitopd/pthub3/pthub3.py
@@ -87,7 +87,7 @@ def get_oled_pi_control_state():
 
 
 def get_oled_use_spi0():
-    return _state.oled_is_using_spi0
+    return _hub_connection.read_oled_use_spi0()
 
 
 def get_lid_open_state():

--- a/pitopd/pthub3/pthub3.py
+++ b/pitopd/pthub3/pthub3.py
@@ -62,6 +62,7 @@ def reset_oled():
 
 
 def set_oled_use_spi0(use_spi0):
+    _state.set_oled_using_spi0_state(use_spi0)
     _hub_connection.set_oled_use_spi0(use_spi0)
 
 

--- a/pitopd/pthub3/pthub3_connection.py
+++ b/pitopd/pthub3/pthub3_connection.py
@@ -773,7 +773,7 @@ class HubConnection:
         spi_bus_changed = spi_bus != state_spi_bus
         if spi_bus_changed:
             logger.warning(
-                f"SPI bus number changed unexpectedly from '{state_spi_bus}' to '{spi_bus}'"
+                f"SPI bus number changed unexpectedly from '{state_spi_bus}' to '{spi_bus}'... reverting to '{state_spi_bus}'"
             )
 
         self._state.set_oled_using_spi0_state(

--- a/pitopd/pthub3/pthub3_connection.py
+++ b/pitopd/pthub3/pthub3_connection.py
@@ -767,7 +767,10 @@ class HubConnection:
 
         state_spi_bus = self._state.oled_spi_bus
         spi_bus = OledSpi.BUS1 if spi_bus_bits == 0 else OledSpi.BUS0
-        spi_bus_changed = state_spi_bus != OledSpi.UNKNOWN and spi_bus != state_spi_bus
+        if state_spi_bus == OledSpi.UNKNOWN:
+            state_spi_bus = spi_bus
+
+        spi_bus_changed = spi_bus != state_spi_bus
         if spi_bus_changed:
             logger.warning(
                 f"SPI bus number changed unexpectedly from '{state_spi_bus}' to '{spi_bus}'"

--- a/pitopd/pthub3/pthub3_connection.py
+++ b/pitopd/pthub3/pthub3_connection.py
@@ -770,15 +770,12 @@ class HubConnection:
         if state_spi_bus == OledSpi.UNKNOWN:
             state_spi_bus = spi_bus
 
-        spi_bus_changed = spi_bus != state_spi_bus
-        if spi_bus_changed:
+        if spi_bus != state_spi_bus:
             logger.warning(
                 f"SPI bus number changed unexpectedly from '{state_spi_bus}' to '{spi_bus}'... reverting to '{state_spi_bus}'"
             )
-
-        self._state.set_oled_using_spi0_state(
-            state_spi_bus == OledSpi.BUS0, force=spi_bus_changed
-        )
+            self._state.set_oled_using_spi0_state(state_spi_bus == OledSpi.BUS0)
+            self.set_oled_use_spi0(state_spi_bus == OledSpi.BUS0)
 
     def _read_ui_buttons_register(self):
         logger.debug("Hub: Reading UI button register")

--- a/pitopd/pthub3/pthub3_connection.py
+++ b/pitopd/pthub3/pthub3_connection.py
@@ -759,11 +759,18 @@ class HubConnection:
                 oled_controlled_state,
             )
         )
-        self._state.set_oled_using_spi0_state(
-            bitwise_ops.get_bits(
-                OLEDControlRegister.CTRL__UI_OLED_CTRL__SPI_ALT, oled_controlled_state
-            )
+
+        spi_bus_bits = bitwise_ops.get_bits(
+            OLEDControlRegister.CTRL__UI_OLED_CTRL__SPI_ALT, oled_controlled_state
         )
+        spi_bus = "1" if spi_bus_bits == 0 else "0"
+        expected_bus = self._state.oled_is_using_spi0
+        if spi_bus != expected_bus:
+            logger.warning(
+                "SPI bus number changed unexpectedly from '{expected_bus}' to '{spi_bus}'"
+            )
+
+        self._state.set_oled_using_spi0_state(expected_bus)
 
     def _read_ui_buttons_register(self):
         logger.debug("Hub: Reading UI button register")

--- a/pitopd/pthub3/pthub3_connection.py
+++ b/pitopd/pthub3/pthub3_connection.py
@@ -766,16 +766,20 @@ class HubConnection:
         )
 
         state_spi_bus = self._state.oled_spi_bus
-        spi_bus = OledSpi.BUS1 if spi_bus_bits == 0 else OledSpi.BUS0
-        if state_spi_bus == OledSpi.UNKNOWN:
-            state_spi_bus = spi_bus
+        hub_spi_bus = OledSpi.BUS1 if spi_bus_bits == 0 else OledSpi.BUS0
 
-        if spi_bus != state_spi_bus:
+        if hub_spi_bus == state_spi_bus and state_spi_bus != OledSpi.UNKNOWN:
+            return
+
+        if state_spi_bus == OledSpi.UNKNOWN:
+            self._state.oled_spi_bus = hub_spi_bus
+        else:
             logger.warning(
-                f"SPI bus number changed unexpectedly from '{state_spi_bus}' to '{spi_bus}'... reverting to '{state_spi_bus}'"
+                f"SPI bus number changed unexpectedly from '{state_spi_bus}' to '{hub_spi_bus}'... reverting to '{state_spi_bus}'"
             )
-            self._state.set_oled_using_spi0_state(state_spi_bus == OledSpi.BUS0)
-            self.set_oled_use_spi0(state_spi_bus == OledSpi.BUS0)
+
+        self._state.set_oled_using_spi0_state(state_spi_bus == OledSpi.BUS0)
+        self.set_oled_use_spi0(state_spi_bus == OledSpi.BUS0)
 
     def _read_ui_buttons_register(self):
         logger.debug("Hub: Reading UI button register")

--- a/pitopd/pthub3/pthub3_connection.py
+++ b/pitopd/pthub3/pthub3_connection.py
@@ -780,6 +780,7 @@ class HubConnection:
 
         self._state.set_oled_using_spi0_state(state_spi_bus == OledSpi.BUS0)
         self.set_oled_use_spi0(state_spi_bus == OledSpi.BUS0)
+        self._state.emit_oled_spi_bus_state_changed()
 
     def _read_ui_buttons_register(self):
         logger.debug("Hub: Reading UI button register")

--- a/pitopd/pthub3/pthub3_state.py
+++ b/pitopd/pthub3/pthub3_state.py
@@ -174,8 +174,8 @@ class State:
             self.oled_is_pi_controlled = is_pi_controlled
             self.emit_oled_pi_control_state_changed()
 
-    def set_oled_using_spi0_state(self, is_using_spi0, force=False):
-        if (self.oled_is_using_spi0 != is_using_spi0) or force:
+    def set_oled_using_spi0_state(self, is_using_spi0):
+        if self.oled_is_using_spi0 != is_using_spi0:
             self.oled_is_using_spi0 = is_using_spi0
             self.emit_oled_spi_bus_state_changed()
 

--- a/pitopd/pthub3/pthub3_state.py
+++ b/pitopd/pthub3/pthub3_state.py
@@ -180,8 +180,8 @@ class State:
             self.oled_is_pi_controlled = is_pi_controlled
             self.emit_oled_pi_control_state_changed()
 
-    def set_oled_using_spi0_state(self, is_using_spi0):
-        if self.oled_is_using_spi0 != is_using_spi0:
+    def set_oled_using_spi0_state(self, is_using_spi0, force=False):
+        if (self.oled_is_using_spi0 != is_using_spi0) or force:
             self.oled_is_using_spi0 = is_using_spi0
             self.emit_oled_spi_bus_state_changed()
 

--- a/pitopd/pthub3/pthub3_state.py
+++ b/pitopd/pthub3/pthub3_state.py
@@ -1,4 +1,15 @@
+import logging
+from enum import Enum, auto
+
 from ..event import AppEvents, event_emitter
+
+logger = logging.getLogger(__name__)
+
+
+class OledSpi(Enum):
+    BUS0 = auto()
+    BUS1 = auto()
+    UNKNOWN = auto()
 
 
 class State:
@@ -12,15 +23,23 @@ class State:
         self.battery_capacity = -1
         self.buttons_route_to_gpio_enabled = False
         self.oled_is_pi_controlled = False
-        self.oled_is_using_spi0 = False
         self.up_button_press_state = False
         self.down_button_press_state = False
         self.select_button_press_state = False
         self.cancel_button_press_state = False
+        self.oled_spi_bus = OledSpi.UNKNOWN
 
         self.battery_capacity_override_counter = 0
 
         self.funcs = None
+
+    @property
+    def oled_is_using_spi0(self):
+        return self.oled_spi_bus == OledSpi.BUS0
+
+    @oled_is_using_spi0.setter
+    def oled_is_using_spi0(self, is_using_spi0):
+        self.oled_spi_bus = OledSpi.BUS0 if is_using_spi0 else OledSpi.BUS1
 
     def register_client(self, funcs):
         self.funcs = funcs
@@ -162,7 +181,7 @@ class State:
             self.emit_oled_pi_control_state_changed()
 
     def set_oled_using_spi0_state(self, is_using_spi0):
-        if self.oled_is_using_spi0 is not is_using_spi0:
+        if self.oled_is_using_spi0 != is_using_spi0:
             self.oled_is_using_spi0 = is_using_spi0
             self.emit_oled_spi_bus_state_changed()
 

--- a/pitopd/pthub3/pthub3_state.py
+++ b/pitopd/pthub3/pthub3_state.py
@@ -1,8 +1,6 @@
 import logging
 from enum import Enum, auto
 
-from ..event import AppEvents, event_emitter
-
 logger = logging.getLogger(__name__)
 
 
@@ -65,10 +63,6 @@ class State:
             func(self.oled_is_pi_controlled)
 
     def emit_oled_spi_bus_state_changed(self):
-        event_emitter.emit(
-            AppEvents.SPI_BUS_CHANGED, 0 if self.oled_is_using_spi0 else 1
-        )
-
         func = self.funcs.get("oled_spi_state")
         if callable(func):
             func(self.oled_is_using_spi0)

--- a/pitopd/server/request_server.py
+++ b/pitopd/server/request_server.py
@@ -214,7 +214,6 @@ class RequestServer:
                     target=self._callback_client.on_request_set_oled_spi_bus,
                     args=[int(message.parameters[0])],
                 ).start()
-
                 response = Message.from_parts(Message.RSP_SET_OLED_SPI_BUS)
 
             else:


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/OS-1304) |


#### Main changes
This PR implements a workaround for the bug that changes the SPI bus in the hub of a pi-top[4] by making sure that the only valid way to change the SPI bus used by the OLED is through pi-topd, rolling back any changes to it if done any other way.

Basically:
- On initialization, the SPI bus value, read from the hub, is stored in the app internal state.
- Whenever there's a request to pi-topd asking to update the SPI bus it updates the internal state.
- On initialization, a thread runs in the background continuously reading the OLED registers from the hub. If this value differs from the one in the internal state of the app, it will consider that it's an unexpected change, and will write the value set in state into the hub.

#### Screenshots (feature, test output, profiling, dev tools etc)

N/A

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
To reproduce the bug, we can write values directly into the hub using the SDK.

Steps:
- Install artifacts
- Restart pi-topd. Run `sudo systemctl restart pi-topd`.
- Read the current SPI bus. Run `pi-top oled spi`.
- Force the OLED to use SPI bus 1. Run `pi-top oled spi 1`.
- Confirm the change was applied: `pi-top oled spi` should return `1`
- Change the SPI bus by writing to the hub. In a python interpreter, run:
```
from pitop.common.i2c_device import I2CDevice

i2c_device = I2CDevice("/dev/i2c-1", 0x11)
i2c_device.set_delays(0.001, 0.001)
i2c_device.connect()

# OLED uses SPI bus 0
i2c_device.write_byte(0x14, 0b101)
```
- Check the SPI bus again using the CLI: `pi-top oled spi` should return `1`, since writing to the register directly is not a valid way to set the SPI bus.

#### Tag anyone who definitely needs to review or help
-
