### PR TITLE
Fix deb-release workflow

### DIFF
--- a/.github/workflows/deb-release.yml
+++ b/.github/workflows/deb-release.yml
@@ -2,8 +2,6 @@ name: Create GitHub Release
 
 on:
   workflow_dispatch:
-    branches:
-      - master
 
 env:
   DEB_BUILD_DOCKER_IMAGE: "pitop/pi-top-os-deb-build"


### PR DESCRIPTION
There's apparently an issue with the usage of `workflow_dispatch` and `branches` in Github workflows: https://github.community/t/worflow-with-dispatch-and-branches-setting-suddenly-not-supported-anymore/247732/18

This PR removes `branches`. Since it the default branch is `master`, the workflow should continue to work.