### PR TITLE
Send messages only when app is initialized

### DIFF
--- a/pitopd/app.py
+++ b/pitopd/app.py
@@ -110,6 +110,7 @@ class App:
 
         logger.info("Configured for dependencies - unblocking systemd")
         notify("READY=1")
+        self._publish_server.publish_pitopd_ready()
 
         if self.device_id != last_identified_device_id:
             logger.info(

--- a/pitopd/app.py
+++ b/pitopd/app.py
@@ -110,6 +110,7 @@ class App:
 
         logger.info("Configured for dependencies - unblocking systemd")
         notify("READY=1")
+        self._publish_server.emit_messages = True
         self._publish_server.publish_pitopd_ready()
 
         if self.device_id != last_identified_device_id:

--- a/pitopd/server/publish_server.py
+++ b/pitopd/server/publish_server.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 # and publishes state change messages to these clients
 class PublishServer:
     def __init__(self):
+        self._emit_messages = False
         self._socket_lock = Lock()
         self._shutting_down = False
         self._zmq_context = None
@@ -156,12 +157,14 @@ class PublishServer:
             parameters = list()
         message = Message.from_parts(message_id, parameters)
 
-        if self._zmq_socket is None:
-            logger.info(
-                "Not publishing message: "
-                + message.message_friendly_string()
-                + " - publish server not ready"
+        if self._zmq_socket is None or not self._emit_messages:
+            msg = f"Not publishing message: {message.message_friendly_string()}"
+            msg += (
+                " - publish server not ready"
+                if self._zmq_socket is None
+                else " - pi-topd not initialized"
             )
+            logger.info(msg)
             return
 
         if log_message:

--- a/pitopd/server/publish_server.py
+++ b/pitopd/server/publish_server.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 # and publishes state change messages to these clients
 class PublishServer:
     def __init__(self):
-        self._emit_messages = False
+        self.emit_messages = False
         self._socket_lock = Lock()
         self._shutting_down = False
         self._zmq_context = None
@@ -148,7 +148,6 @@ class PublishServer:
         )
 
     def publish_pitopd_ready(self):
-        self._emit_messages = True
         self._send_message(Message.PUB_PITOPD_READY)
 
     # Internal functions
@@ -157,7 +156,7 @@ class PublishServer:
             parameters = list()
         message = Message.from_parts(message_id, parameters)
 
-        if self._zmq_socket is None or not self._emit_messages:
+        if self._zmq_socket is None or not self.emit_messages:
             msg = f"Not publishing message: {message.message_friendly_string()}"
             msg += (
                 " - publish server not ready"

--- a/pitopd/server/publish_server.py
+++ b/pitopd/server/publish_server.py
@@ -146,6 +146,10 @@ class PublishServer:
             Message.PUB_OLED_SPI_BUS_CHANGED, [0 if oled_uses_spi0 else 1]
         )
 
+    def publish_pitopd_ready(self):
+        self._emit_messages = True
+        self._send_message(Message.PUB_PITOPD_READY)
+
     # Internal functions
     def _send_message(self, message_id, parameters=None, log_message=True):
         if parameters is None:


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/OS-1379) |


#### Main changes

When the application starts, several messages are being published after the hub is polled to learn the current state of the hub. This causes issues since messages will be sent even if the event that triggers them isn't happening. 

The messages that are currently being sent every time the application starts are:
```
PUB_BATTERY_STATE_CHANGED
PUB_OLED_CONTROL_CHANGED
PUB_OLED_SPI_BUS_CHANGED
PUB_V3_BUTTON_UP_RELEASED
PUB_V3_BUTTON_DOWN_RELEASED
PUB_V3_BUTTON_SELECT_RELEASED
PUB_V3_BUTTON_CANCEL_RELEASED
```

The changes in this PR will cause `pi-topd` to stop sending these messages until the app is initialized. Also, a new message `PUB_PITOPD_READY` is published when this happens, to let other applications know about this.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
