### PR TITLE
Fix dependency name: pitop-common -> pitop.common

### DIFF
--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -2,7 +2,7 @@ click python3-click; PEP386
 click-logging python3-click-logging; PEP386
 # Package will always update in-step with SDK
 # So avoid version-locking
-pitop-common python3-pitop-common
+pitop.common python3-pitop-common
 # smbus2 is a pure Python implementation of the python-smbus package
 # Versions do not match so ignore PEP386
 smbus2 python3-smbus

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ python_requires = >=3.9, <4
 install_requires =
     # Package will always update in-step with SDK
     # So avoid version-locking
-    pitop-common
+    pitop.common
     click>=7.1.2,<7.2
     click-logging>1.0.1,<1.1
     smbus2>=0.4.0,<0.5


### PR DESCRIPTION
#### Main changes

Fix dependency name from `pitop-common` to `pitop.common`, which caused issues when installing the package using `setup.py`

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
