### PR TITLE
Fix dependency version specification in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     click>=7.1.2,<7.2
     click-logging>1.0.1,<1.1
     smbus2>=0.4.0,<0.5
-    spidev>=3.5<3.6
+    spidev>=3.5,<3.6
     # For journal logging
     systemd-python>=234,<235
     # Device Communication


### PR DESCRIPTION
There is a complaint about bogus dependency when installing pi-topd

Add missing comma to avoid the error.

Signed-off-by: Michal Suchanek <msuchanek@suse.de>

| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/<ticket-number>) |


#### Main changes
-

#### Screenshots (feature, test output, profiling, dev tools etc)

[   13s] Traceback (most recent call last):
[   13s]   File "/usr/lib/python3.10/site-packages/packaging/requirements.py", line 35, in __init__
[   13s]     parsed = parse_requirement(requirement_string)
[   13s]   File "/usr/lib/python3.10/site-packages/packaging/_parser.py", line 64, in parse_requirement
[   13s]     return _parse_requirement(Tokenizer(source, rules=DEFAULT_RULES))
[   13s]   File "/usr/lib/python3.10/site-packages/packaging/_parser.py", line 82, in _parse_requirement
[   13s]     url, specifier, marker = _parse_requirement_details(tokenizer)
[   13s]   File "/usr/lib/python3.10/site-packages/packaging/_parser.py", line 122, in _parse_requirement_details
[   13s]     marker = _parse_requirement_marker(
[   13s]   File "/usr/lib/python3.10/site-packages/packaging/_parser.py", line 143, in _parse_requirement_marker
[   13s]     tokenizer.raise_syntax_error(
[   13s]   File "/usr/lib/python3.10/site-packages/packaging/_tokenizer.py", line 161, in raise_syntax_error
[   13s]     raise ParserSyntaxError(
[   13s] packaging._tokenizer.ParserSyntaxError: Expected end or semicolon (after version specifier)
[   13s]     spidev>=3.5<3.6
[   13s]           ~~~~~^
[   13s] 
[   13s] The above exception was the direct cause of the following exception:
[   13s] 
[   13s] Traceback (most recent call last):
[   13s]   File "/usr/lib/rpm/pythondistdeps.py", line 561, in <module>
[   13s]     main()
[   13s]   File "/usr/lib/rpm/pythondistdeps.py", line 372, in main
[   13s]     dist = Distribution(f)
[   13s]   File "/usr/lib/rpm/pythondistdeps.py", line 86, in __init__
[   13s]     self.requirements = [Requirement(r) for r in self.requires or []]
[   13s]   File "/usr/lib/rpm/pythondistdeps.py", line 86, in <listcomp>
[   13s]     self.requirements = [Requirement(r) for r in self.requires or []]
[   13s]   File "/usr/lib/rpm/pythondistdeps.py", line 68, in __init__
[   13s]     super(Requirement, self).__init__(requirement_string)
[   13s]   File "/usr/lib/python3.10/site-packages/packaging/requirements.py", line 37, in __init__
[   13s]     raise InvalidRequirement(str(e)) from e
[   13s] packaging.requirements.InvalidRequirement: Expected end or semicolon (after version specifier)
[   13s]     spidev>=3.5<3.6
[   13s]           ~~~~~^
[   13s] 
[   13s] The above exception was the direct cause of the following exception:
[   13s] 
[   13s] Traceback (most recent call last):
[   13s]   File "/usr/lib/rpm/pythondistdeps.py", line 564, in <module>
[   13s]     raise RuntimeError("Error: pythondistdeps.py generator encountered an unhandled exception and was terminated.") from exc
[   13s] RuntimeError: Error: pythondistdeps.py generator encountered an unhandled exception and was terminated.
[   13s] error: Dependency tokens must begin with alpha-numeric, '_' or '/': *** PYTHONDISTDEPS_GENERATORS_FAILED ***


#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
