### PR TITLE
Fix click-logging dependency.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     # So avoid version-locking
     pitop.common
     click>=7.1.2,<7.2
-    click-logging>1.0.1,<1.1
+    click-logging>=1.0.1,<1.1
     smbus2>=0.4.0,<0.5
     spidev>=3.5,<3.6
     # For journal logging


### PR DESCRIPTION
setup.cfg specifies dependency on click-logging > 1.0.1 but only 1.0.1 exists.

Signed-off-by: Michal Suchanek <msuchanek@suse.de>

| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/<ticket-number>) |


#### Main changes
-

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
