### PR TITLE
Ignore version lock for spidev on Debian package

### DIFF
--- a/debian/py3dist-overrides
+++ b/debian/py3dist-overrides
@@ -6,7 +6,7 @@ pitop.common python3-pitop-common
 # smbus2 is a pure Python implementation of the python-smbus package
 # Versions do not match so ignore PEP386
 smbus2 python3-smbus
-spidev python3-spidev; PEP386
+spidev python3-spidev
 # Journal handling
 systemd_python python3-systemd; PEP386
 # System state change communication


### PR DESCRIPTION
#### Main changes
`python3-spidev` package version on Debian uses the release date; currently it's `20200602~200721-1` so it fails to install when using `PEP386` to match the python version to the Debian version.

#### Screenshots (feature, test output, profiling, dev tools etc)

[insert screenshots here]

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
-

#### Manual testing tips
-

#### Tag anyone who definitely needs to review or help
-
